### PR TITLE
Allow Ceph only on suse-12.0 nodes

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -48,34 +48,30 @@ class CephService < PacemakerServiceObject
         "ceph-calamari" => {
           "unique" => false,
           "count" => 1,
-          "exclude_platform" => {
-            "suse" => "< 12.0",
-            "windows" => "/.*/"
+          "platform" => {
+            "suse" => "12.0"
           },
           "conflicts_with" => ["ceph-mon", "ceph-osd", "ceph-radosgw", "nova_dashboard-server"]
         },
         "ceph-mon" => {
           "unique" => false,
           "count" => 3,
-          "exclude_platform" => {
-            "suse" => "< 12.0",
-            "windows" => "/.*/"
-          }
+          "platform" => {
+            "suse" => "12.0"
+          },
         },
         "ceph-osd" => {
           "unique" => false,
           "count" => 8,
-          "exclude_platform" => {
-            "suse" => "< 12.0",
-            "windows" => "/.*/"
-          }
+          "platform" => {
+            "suse" => "12.0"
+          },
         },
         "ceph-radosgw" => {
           "unique" => false,
           "count" => 1,
-          "exclude_platform" => {
-            "suse" => "< 12.0",
-            "windows" => "/.*/"
+          "platform" => {
+            "suse" => "12.0"
           },
           "cluster" => true
         }


### PR DESCRIPTION
SES2 can not be deployed on SLE12 SP1, so require SLE12 SP0
