### PR TITLE
Increase limits for ceph-mon and ceph-osd nodes

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -55,14 +55,14 @@ class CephService < PacemakerServiceObject
         },
         "ceph-mon" => {
           "unique" => false,
-          "count" => 3,
+          "count" => 9,
           "platform" => {
             "suse" => "12.0"
           },
         },
         "ceph-osd" => {
           "unique" => false,
-          "count" => 8,
+          "count" => 150,
           "platform" => {
             "suse" => "12.0"
           },


### PR DESCRIPTION
I don't know why we have such low limits for ceph-mon and ceph-osd numbers, but it is wrong.
