### PR TITLE
Do not pass delaylog option when mounting xfs partitions

### DIFF
--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -127,7 +127,7 @@
         osd mkfs type = xfs
         ; If you want to specify some other mount options, you can do so.
         ; for other filesystems use 'osd mount options $fstype'
-    osd mount options xfs = rw,noatime,inode64,logbsize=256k,delaylog
+    osd mount options xfs = rw,noatime,inode64,logbsize=256k
     ; The options used to format the filesystem via mkfs.$fstype
         ; for other filesystems use 'osd mkfs options $fstype'
     ; osd mkfs options btrfs =


### PR DESCRIPTION
This option is deprecated for quite some time, was marked as scheduled
for removal in kernel 3.12 back in 2013-07:
    http://oss.sgi.com/archives/xfs/2013-07/msg00143.html
and was dropped in kernel 3.20 in 2015-02:
    http://oss.sgi.com/archives/xfs/2015-02/msg00306.html

Note that we have 3.12 in SLES 12 SP1 and 4.1.13 in Leap.
