### PR TITLE
drop rubocop from Code Climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,4 @@
 engines:
-  rubocop:
-    enabled: true
-    config: .hound.ruby.yml
   eslint:
     enabled: true
   csslint:


### PR DESCRIPTION
We already have Hound CI which is a bit nicer than Code Climate for rubocop linting, because it comments on style failures inline within the pull request.  Plus Code Climate's rubocop seems to be triggering some false failures.
