### PR TITLE
Set rake to version to 10.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@
 
 source "https://rubygems.org"
 
+gem "rake", "~> 10.3.2"
+
 group :development do
   gem "closure-compiler", "~> 1.1.10"
   gem "sass", "~> 3.2.19"


### PR DESCRIPTION
This change is needed due to the incompatibility with rake 11.0.0.
