### PR TITLE
Revert "Workaround Ceph hanging QEMU on volume attach (bsc#967509)"

### DIFF
--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -1,5 +1,4 @@
 [global]
-        rbd_non_blocking_aio = false
         ; enable secure authentication
         auth cluster required = cephx
         auth service required = cephx


### PR DESCRIPTION
This reverts commit c7aceac83159856ff14ce414f2fd6fa795dc2e69. It's
no longer needed because it's fixed in Ceph.
