### PR TITLE
Support deploying Ceph Jewel release (bsc#970510)

### DIFF
--- a/chef/cookbooks/ceph/attributes/radosgw.rb
+++ b/chef/cookbooks/ceph/attributes/radosgw.rb
@@ -33,8 +33,8 @@ when "debian"
     default["ceph"]["radosgw"]["service_name"] = "radosgw-all-starter"
   end
 when "suse"
-  # need "radosgw.HOSTNAME" for jewel; earlier versions just used "HOSTNAME"
-  default["ceph"]["radosgw"]["service_name"] = "ceph-radosgw@radosgw.#{node["hostname"]}"
+  # need "rgw.HOSTNAME" for jewel; earlier versions just used "HOSTNAME"
+  default["ceph"]["radosgw"]["service_name"] = "ceph-radosgw@rgw.#{node["hostname"]}"
   default["ceph"]["radosgw"]["user"] = "ceph"
   default["ceph"]["radosgw"]["group"] = "ceph"
 else

--- a/chef/cookbooks/ceph/attributes/radosgw.rb
+++ b/chef/cookbooks/ceph/attributes/radosgw.rb
@@ -33,9 +33,10 @@ when "debian"
     default["ceph"]["radosgw"]["service_name"] = "radosgw-all-starter"
   end
 when "suse"
-  default["ceph"]["radosgw"]["service_name"] = "ceph-radosgw@#{node["hostname"]}"
-  default["ceph"]["radosgw"]["user"] = "wwwrun"
-  default["ceph"]["radosgw"]["group"] = "www"
+  # need "radosgw.HOSTNAME" for jewel; earlier versions just used "HOSTNAME"
+  default["ceph"]["radosgw"]["service_name"] = "ceph-radosgw@radosgw.#{node["hostname"]}"
+  default["ceph"]["radosgw"]["user"] = "ceph"
+  default["ceph"]["radosgw"]["group"] = "ceph"
 else
   default["ceph"]["radosgw"]["service_name"] = "ceph-radosgw"
 end

--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -9,6 +9,8 @@ mon_nodes.each do |monitor|
     mon_init << monitor.name.split(".")[0]
 end
 
+# These directories should all be created by the package, maybe we can
+# just remove this stuff...?  (same with the directories created in osd.rb)
 directory "/etc/ceph" do
   owner "root"
   group "root"
@@ -17,16 +19,16 @@ directory "/etc/ceph" do
 end
 
 directory "/var/run/ceph" do
-  owner "root"
-  group "root"
-  mode "0755"
+  owner "ceph"
+  group "ceph"
+  mode "0770"
   action :create
 end
 
 directory "/var/log/ceph" do
-  owner "root"
-  group "root"
-  mode "0755"
+  owner "ceph"
+  group "ceph"
+  mode "3770"
   action :create
 end
 

--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -9,27 +9,29 @@ mon_nodes.each do |monitor|
     mon_init << monitor.name.split(".")[0]
 end
 
-# These directories should all be created by the package, maybe we can
-# just remove this stuff...?  (same with the directories created in osd.rb)
-directory "/etc/ceph" do
-  owner "root"
-  group "root"
-  mode "0755"
-  action :create
-end
+unless node["platform_family"] == "suse"
+  # These directories are all created by the ceph packages on SUSE distros.
+  # TODO: Check if this is true for other distros (it probably is)
+  directory "/etc/ceph" do
+    owner "root"
+    group "root"
+    mode "0755"
+    action :create
+  end
 
-directory "/var/run/ceph" do
-  owner "ceph"
-  group "ceph"
-  mode "0770"
-  action :create
-end
+  directory "/var/run/ceph" do
+    owner "ceph"
+    group "ceph"
+    mode "0770"
+    action :create
+  end
 
-directory "/var/log/ceph" do
-  owner "ceph"
-  group "ceph"
-  mode "3770"
-  action :create
+  directory "/var/log/ceph" do
+    owner "ceph"
+    group "ceph"
+    mode "3770"
+    action :create
+  end
 end
 
 is_rgw = node.roles.include?("ceph-radosgw")

--- a/chef/cookbooks/ceph/recipes/mon.rb
+++ b/chef/cookbooks/ceph/recipes/mon.rb
@@ -131,10 +131,15 @@ service "ceph_mon" do
   subscribes :restart, resources(template: "/etc/ceph/ceph.conf")
 end
 
-# In addition to the mon service, ceph.target must be enabled when using systemd
-service "ceph.target" do
-  action :enable
-end if service_type == "systemd"
+# In addition to the mon service, ceph targets must be enabled when using systemd
+if service_type == "systemd"
+  service "ceph-mon.target" do
+    action :enable
+  end
+  service "ceph.target" do
+    action :enable
+  end
+end
 
 execute "Create Ceph client.admin key when ceph-mon is ready" do
   command "ceph-create-keys -i #{node['hostname']}"

--- a/chef/cookbooks/ceph/recipes/mon.rb
+++ b/chef/cookbooks/ceph/recipes/mon.rb
@@ -21,9 +21,9 @@ include_recipe "ceph::conf"
 service_type = node["ceph"]["mon"]["init_style"]
 
 directory "/var/lib/ceph/mon/ceph-#{node["hostname"]}" do
-  owner "root"
-  group "root"
-  mode "0755"
+  owner "ceph"
+  group "ceph"
+  mode "0750"
   recursive true
   action :create
 end

--- a/chef/cookbooks/ceph/recipes/mon.rb
+++ b/chef/cookbooks/ceph/recipes/mon.rb
@@ -91,7 +91,7 @@ unless File.exists?("/var/lib/ceph/mon/ceph-#{node["hostname"]}/done")
   end
 
   execute "ceph-mon mkfs" do
-    command "ceph-mon --mkfs -i #{node['hostname']} --keyring '#{keyring}'"
+    command "chown ceph:ceph #{keyring} ; ceph-mon --mkfs -i #{node['hostname']} --keyring '#{keyring}' --setuser ceph --setgroup ceph"
     action :nothing
   end
 

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -47,6 +47,8 @@ elsif mons[0]["ceph"]["bootstrap-osd-secret"].empty?
   Chef::Log.fatal("No authorization keys found")
 else
 
+  # These directories are all created by the ceph packages on SUSE distros.
+  # TODO: Check if this is true for other distros (it probably is)
   ["tmp", "osd", "bootstrap-osd"].each do |name|
     directory "/var/lib/ceph/#{name}" do
       owner "ceph"
@@ -55,7 +57,7 @@ else
       recursive true
       action :create
     end
-  end
+  end unless node["platform_family"] == "suse"
 
   # TODO cluster name
   cluster = "ceph"

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -222,10 +222,15 @@ else
         subscribes :restart, resources(template: "/etc/ceph/ceph.conf")
       end unless service_type == "systemd"
 
-      # In addition to the osd services, ceph.target must be enabled when using systemd
-      service "ceph.target" do
-        action :enable
-      end if service_type == "systemd"
+      # In addition to the osd services, ceph targets must be enabled when using systemd
+      if service_type == "systemd"
+        service "ceph-osd.target" do
+          action :enable
+        end
+        service "ceph.target" do
+          action :enable
+        end
+      end
     end
   end
 end

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -49,9 +49,9 @@ else
 
   ["tmp", "osd", "bootstrap-osd"].each do |name|
     directory "/var/lib/ceph/#{name}" do
-      owner "root"
-      group "root"
-      mode "0755"
+      owner "ceph"
+      group "ceph"
+      mode "0750"
       recursive true
       action :create
     end

--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -61,6 +61,8 @@ unless node[:ceph][:keystone_instance].nil? || node[:ceph][:keystone_instance].e
   include_recipe "ceph::radosgw_keystone"
 end
 
+# TODO: we probably need to enable ceph-radosgw.target and
+# ceph.target here as well, in the systemd case
 service "radosgw" do
   service_name node["ceph"]["radosgw"]["service_name"]
   supports restart: true

--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -36,7 +36,7 @@ include_recipe "ceph::radosgw_civetweb"
 
 crowbar_pacemaker_sync_mark "wait-ceph_client_generate"
 
-ceph_client "radosgw" do
+ceph_client "rgw" do
   caps("mon" => "allow rw", "osd" => "allow rwx")
   owner "root"
   group node["ceph"]["radosgw"]["group"]

--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -13,25 +13,6 @@ end
 
 hostname = node["hostname"]
 
-directory "/var/log/radosgw" do
-  owner node["ceph"]["radosgw"]["user"]
-  group node["ceph"]["radosgw"]["group"]
-  mode "0755"
-  action :create
-end
-
-file "/var/log/radosgw/radosgw.log" do
-  owner node["ceph"]["radosgw"]["user"]
-  group node["ceph"]["radosgw"]["group"]
-end
-
-directory "/var/run/ceph-radosgw" do
-  owner node["ceph"]["radosgw"]["user"]
-  group node["ceph"]["radosgw"]["group"]
-  mode "0755"
-  action :create
-end
-
 include_recipe "ceph::radosgw_civetweb"
 
 crowbar_pacemaker_sync_mark "wait-ceph_client_generate"

--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -61,13 +61,21 @@ unless node[:ceph][:keystone_instance].nil? || node[:ceph][:keystone_instance].e
   include_recipe "ceph::radosgw_keystone"
 end
 
-# TODO: we probably need to enable ceph-radosgw.target and
-# ceph.target here as well, in the systemd case
 service "radosgw" do
   service_name node["ceph"]["radosgw"]["service_name"]
   supports restart: true
   action [:enable, :start]
   subscribes :restart, "template[/etc/ceph/ceph.conf]"
+end
+
+# In the systemd case, need extra targets enabled
+service "ceph-radosgw.target" do
+  action :enable
+  only_if { File.exist?("/usr/lib/systemd/system/ceph-radosgw.target") }
+end
+service "ceph.target" do
+  action :enable
+  only_if { File.exist?("/usr/lib/systemd/system/ceph.target") }
 end
 
 if node[:ceph][:ha][:radosgw][:enabled]

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -140,13 +140,9 @@
 <% end -%>
 
 <% if (@is_rgw) -%>
-[client.radosgw.<%= node['hostname'] %>]
+[client.rgw.<%= node['hostname'] %>]
   host = <%= node['hostname'] %>
-  rgw socket path = /var/run/ceph-radosgw/radosgw.<%= node['hostname'] %>
-  admin socket = /var/run/ceph-radosgw/ceph-client.radosgw.<%= node['hostname'] %>.asok
-  pid file = /var/run/ceph-radosgw/$name.pid
-  keyring = /etc/ceph/ceph.client.radosgw.<%= node['hostname'] %>.keyring
-  log file = /var/log/radosgw/radosgw.log
+  keyring = /etc/ceph/ceph.client.rgw.<%= node['hostname'] %>.keyring
   rgw frontends = civetweb port=<%= @rgw_port %><% if (@rgw_pemfile) %>s ssl_certificate=<%= @rgw_pemfile %><% end %>
   <% unless node[:ceph][:keystone_instance].nil? || node[:ceph][:keystone_instance].empty? -%>
   rgw keystone url =  <%= @keystone_settings['admin_auth_url'] %>


### PR DESCRIPTION
The Ceph Jewel release runs the various ceph daemons as an unprivileged user and group (ceph:ceph), whereas previous releases ran everything as root. There's a bunch of stuff that needs changing in the barclamp to support this. I believe I've got most of it in this PR, but still need to test further.

Also, the changes here effectively _only_ work with Jewel (they rely on the ceph package having created the appropriate user accounts automatically), so if you use this code with an older Ceph release, it will almost certainly fail to deploy. I may be better off trying to make these changes conditionally depending on what version of Ceph is available, but I don't actually know how to check that from within the Chef recipes.
