### PR TITLE
Handle down nodes when searching for MONs and OSDs (bsc#972001)

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -7,7 +7,7 @@ end
 
 def get_mon_nodes(extra_search=nil)
   if is_crowbar?
-    mon_roles = search(:role, 'name:crowbar-* AND run_list:role\[ceph-mon\]')
+    mon_roles = search(:role, "name:crowbar-* AND run_list_map:ceph-mon")
     if not mon_roles.empty?
       search_string = mon_roles.map { |role_object| "roles:"+role_object.name }.join(" OR ")
     else
@@ -130,7 +130,7 @@ end
 def get_osd_nodes()
   osds = []
   if is_crowbar?
-    osd_roles = search(:role, 'name:crowbar-* AND run_list:role\[ceph-osd\]')
+    osd_roles = search(:role, "name:crowbar-* AND run_list_map:ceph-osd")
     if not osd_roles.empty?
       search_string = osd_roles.map { |role_object| "roles:"+role_object.name }.join(" OR ")
     else

--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -63,37 +63,47 @@ else
   num_osds = node["ceph"]["config"]["osds_in_total"]
 end
 
-# There'll always be at least the default rbd pool (which Ceph always creates
-# with 64 PGs, irrespective of what "osd pool default pg num" is set to)
-expected_pools = 1
+case num_osds
+when 0
+  # This can only happen if the search in get_osd_nodes() doesn't find any OSDs, which
+  # should be impossible.  But if it *does* fail, pg_num needs to be set to something,
+  # so let's run with the default of 8 (see "osd pool default pg num" at
+  # http://docs.ceph.com/docs/master/rados/configuration/pool-pg-config-ref/)
+  Chef::Log.warn("Ceph recipe invoked but there are no OSDs!  Defaulting to pg_num = 8")
+  pg_num = 8
+else
+  # There'll always be at least the default rbd pool (which Ceph always creates
+  # with 64 PGs, irrespective of what "osd pool default pg num" is set to)
+  expected_pools = 1
 
-rgw_host = search(:node, "roles:ceph-radosgw")
-# RGW will use up to 14 pools (try "RGW only" with http://ceph.com/pgcalc/)
-# These are not all created immediately though.  Six will be created when
-# the radosgw daemon starts for the first time.  The swift pool(s) will be
-# created when you create a swift subuser for the first time, and the usage
-# pool will only be created if the usage log is explicitly enabled.  Here,
-# to be conservative, we're assuming the full 14 pools will be used for RGW
-# deployments.
-expected_pools += 14 unless rgw_host.empty?
+  rgw_host = search(:node, "roles:ceph-radosgw")
+  # RGW will use up to 14 pools (try "RGW only" with http://ceph.com/pgcalc/)
+  # These are not all created immediately though.  Six will be created when
+  # the radosgw daemon starts for the first time.  The swift pool(s) will be
+  # created when you create a swift subuser for the first time, and the usage
+  # pool will only be created if the usage log is explicitly enabled.  Here,
+  # to be conservative, we're assuming the full 14 pools will be used for RGW
+  # deployments.
+  expected_pools += 14 unless rgw_host.empty?
 
-mds_host = search(:node, "roles:ceph-mds")
-# If there's a ceph MDS (which actually isn't implemented in barclamp yet,
-# but might be in future), there'll be two more pools
-expected_pools += 2 unless mds_host.empty?
+  mds_host = search(:node, "roles:ceph-mds")
+  # If there's a ceph MDS (which actually isn't implemented in barclamp yet,
+  # but might be in future), there'll be two more pools
+  expected_pools += 2 unless mds_host.empty?
 
-# Figure out a sane number for "osd pool default pg num" based on the logic
-# at http://ceph.com/pgcalc/ -- for any given number of expected pools, this
-# results in "about 100" PGs per OSD, but experimentation indicates it can
-# go as low as 70 and as high as 150, depending on the exact number of OSDs
-# and expected number of pools.
-pg_calc = (100 * num_osds * (1.0 / expected_pools)) / rep_num
-# Get nearest power of 2
-pg_num = 2**Math.log2(pg_calc).round
-# Edge case with >=50 pools and 1 OSD gives pg_num of less than 1
-pg_num = 1 if pg_num < 1
-# If nearest power of 2 is more than 25% below original value, use next highest power
-pg_num *= 2 if pg_num < (pg_calc * 0.75)
+  # Figure out a sane number for "osd pool default pg num" based on the logic
+  # at http://ceph.com/pgcalc/ -- for any given number of expected pools, this
+  # results in "about 100" PGs per OSD, but experimentation indicates it can
+  # go as low as 70 and as high as 150, depending on the exact number of OSDs
+  # and expected number of pools.
+  pg_calc = (100 * num_osds * (1.0 / expected_pools)) / rep_num
+  # Get nearest power of 2
+  pg_num = 2**Math.log2(pg_calc).round
+  # Edge case with >=50 pools and 1 OSD gives pg_num of less than 1
+  pg_num = 1 if pg_num < 1
+  # If nearest power of 2 is more than 25% below original value, use next highest power
+  pg_num *= 2 if pg_num < (pg_calc * 0.75)
+end
 
 template "/etc/ceph/ceph.conf" do
   source "ceph.conf.erb"


### PR DESCRIPTION
Searching for OSDs using the query "run_list:role[ceph-osd]" works
fine if all the nodes are up, but if any OSD nodes are down, they're not
returned by this search (somehow the ceph-osd role disappears from the
role run list when the node goes down, and reappears when it comes back
up).  This can lead to a case where a node which is a ceph client hits a
ZeroDivisionError applying the ceph recipe if it comes up before any
OSDs are available (OSD count is zero in this case, at least
transiently).

This commit changes the search to query "run_list_map:ceph_osd", which
seems to work fine regardless of whether nodes are up or down.

Signed-off-by: Tim Serong tserong@suse.com
