### PR TITLE
Set default pg num based based on number of expected pools (bsc#948522)

### DIFF
--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -64,11 +64,14 @@ end
 expected_pools = 1
 
 rgw_host = search(:node, "roles:ceph-radosgw")
-# According to http://docs.ceph.com/docs/master/radosgw/config/, radosgw uses
-# 13 pools.  http://ceph.com/pgcalc/ suggests radosgw uses 12 pools.  Random
-# experimentation suggests it might actually be 11 pools (at least on Ceph
-# Jewel).  So let's pretend it's 12.
-expected_pools += 12 unless rgw_host.empty?
+# RGW will use up to 14 pools (try "RGW only" with http://ceph.com/pgcalc/)
+# These are not all created immediately though.  Six will be created when
+# the radosgw daemon starts for the first time.  The swift pool(s) will be
+# created when you create a swift subuser for the first time, and the usage
+# pool will only be created if the usage log is explicitly enabled.  Here,
+# to be conservative, we're assuming the full 14 pools will be used for RGW
+# deployments.
+expected_pools += 14 unless rgw_host.empty?
 
 mds_host = search(:node, "roles:ceph-mds")
 # If there's a ceph MDS (which actually isn't implemented in barclamp yet,

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -34,14 +34,6 @@
         ; default number of placement groups for placement for a pool
         osd pool default pgp num = <%= @pool_pg_num %>
 
-        # New warning was introduced in Ceph Hammer release
-        # For small RADOS clusters with less than 5 OSDs 
-        # and pools for glance, radosgw, we are getting 
-        # health HEALTH_WARN
-        #        too many PGs per OSD (1216 > max 300)
-        # https://bugzilla.suse.com/show_bug.cgi?id=948375
-        mon_pg_warn_max_per_osd = 0
-
         # Choose a reasonable crush leaf type.
         # 0 for a 1-node cluster.
         # 1 for a multi node cluster in a single rack


### PR DESCRIPTION
This sets "osd pool default pg num" based on the number of OSDs and
number of expected pools, using the logic from http://ceph.com/pgcalc/

It's not perfect, but does result in "about 100" PGs per OSD, regardless
of the number of OSDs and pools, so we should no longer get a "suboptimal"
number of PGs per OSD (bsc#948522), nor an "absurd" number of PGs per OSD
(as reported in bsc#968159, a duplicate of the former bug).

It's still not ideal, because if you look at http://ceph.com/pgcalc/
that assumes that some of the RGW pools will use lots of data, and some
will use little data, so it might be best, for RGW deployments, to
pre-create all the RGW pools rather than allowing them to be
automatically created by the radosgw daemon with the default pg num.
OTOH, that would mean making the barclamp aware of the different RGW
pool names depending on which version of Ceph it's deploying (adding
more comlexity), and probably _still_ wouldn't give a perfect result.

TL;DR: the "osd pool default pg num" setting should be markedly better
now than it was before, and RGW deployments won't result in too many PGs
per OSD.  For truly fine control, one should deploy Ceph, then manually
create the RGW poools, then deploy radosgw.

Signed-off-by: Tim Serong tserong@suse.com
