### PR TITLE
Add "role recipes" with the goal of simplifying the roles

### DIFF
--- a/chef/cookbooks/ceph/recipes/role_ceph_calamari.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_calamari.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceph"
+role = "ceph-calamari"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceph::calamari"
+end

--- a/chef/cookbooks/ceph/recipes/role_ceph_calamari.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_calamari.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, SUSE LINUX GmbH
+# Copyright 2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,4 @@
 # limitations under the License.
 #
 
-barclamp = "ceph"
-role = "ceph-calamari"
-
-# if nil, then this means all states are valid
-states_for_role = node[barclamp]["element_states"][role]
-
-if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
-  include_recipe "ceph::calamari"
-end
+include_recipe "ceph::calamari"

--- a/chef/cookbooks/ceph/recipes/role_ceph_mon.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_mon.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceph"
+role = "ceph-mon"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceph::mon"
+end

--- a/chef/cookbooks/ceph/recipes/role_ceph_mon.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_mon.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, SUSE LINUX GmbH
+# Copyright 2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,4 @@
 # limitations under the License.
 #
 
-barclamp = "ceph"
-role = "ceph-mon"
-
-# if nil, then this means all states are valid
-states_for_role = node[barclamp]["element_states"][role]
-
-if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
-  include_recipe "ceph::mon"
-end
+include_recipe "ceph::mon"

--- a/chef/cookbooks/ceph/recipes/role_ceph_osd.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_osd.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceph"
+role = "ceph-osd"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceph::osd"
+end

--- a/chef/cookbooks/ceph/recipes/role_ceph_osd.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_osd.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, SUSE LINUX GmbH
+# Copyright 2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,4 @@
 # limitations under the License.
 #
 
-barclamp = "ceph"
-role = "ceph-osd"
-
-# if nil, then this means all states are valid
-states_for_role = node[barclamp]["element_states"][role]
-
-if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
-  include_recipe "ceph::osd"
-end
+include_recipe "ceph::osd"

--- a/chef/cookbooks/ceph/recipes/role_ceph_radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_radosgw.rb
@@ -1,0 +1,25 @@
+#
+# Copyright 2015, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp = "ceph"
+role = "ceph-radosgw"
+
+# if nil, then this means all states are valid
+states_for_role = node[barclamp]["element_states"][role]
+
+if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
+  include_recipe "ceph::radosgw"
+end

--- a/chef/cookbooks/ceph/recipes/role_ceph_radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_radosgw.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2015, SUSE LINUX GmbH
+# Copyright 2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,4 @@
 # limitations under the License.
 #
 
-barclamp = "ceph"
-role = "ceph-radosgw"
-
-# if nil, then this means all states are valid
-states_for_role = node[barclamp]["element_states"][role]
-
-if states_for_role.nil? || states_for_role.include?("all") || states_for_role.include?(node[:state])
-  include_recipe "ceph::radosgw"
-end
+include_recipe "ceph::radosgw"

--- a/chef/roles/ceph-calamari.rb
+++ b/chef/roles/ceph-calamari.rb
@@ -1,5 +1,3 @@
 name "ceph-calamari"
 description "Ceph Calamari Server"
-run_list(
-        "recipe[ceph::calamari]"
-)
+run_list("recipe[ceph::role_ceph_calamari]")

--- a/chef/roles/ceph-mds.rb
+++ b/chef/roles/ceph-mds.rb
@@ -1,5 +1,3 @@
 name "ceph-mds"
 description "Ceph Metadata Server"
-run_list(
-        "recipe[ceph::mds]"
-)
+run_list("recipe[ceph::mds]")

--- a/chef/roles/ceph-mds.rb
+++ b/chef/roles/ceph-mds.rb
@@ -1,3 +1,3 @@
 name "ceph-mds"
 description "Ceph Metadata Server"
-run_list("recipe[ceph::mds]")
+run_list("recipe[ceph::role_ceph_mds]")

--- a/chef/roles/ceph-mon.rb
+++ b/chef/roles/ceph-mon.rb
@@ -1,5 +1,3 @@
 name "ceph-mon"
 description "Ceph Monitor"
-run_list(
-        "recipe[ceph::mon]"
-)
+run_list("recipe[ceph::role_ceph_mon]")

--- a/chef/roles/ceph-osd.rb
+++ b/chef/roles/ceph-osd.rb
@@ -1,5 +1,3 @@
 name "ceph-osd"
 description "Ceph Object Storage Device"
-run_list(
-        "recipe[ceph::osd]"
-)
+run_list("recipe[ceph::role_ceph_osd]")

--- a/chef/roles/ceph-radosgw.rb
+++ b/chef/roles/ceph-radosgw.rb
@@ -1,5 +1,3 @@
 name "ceph-radosgw"
 description "Ceph RADOS Gateway"
-run_list(
-        "recipe[ceph::radosgw]"
-)
+run_list("recipe[ceph::role_ceph_radosgw]")


### PR DESCRIPTION
We want the roles to only reference one recipe, so that we can put some
intelligence in that recipe:
- in a first step, we will stop changing the run list of a node
  depending on its state, and instead have the role recipe "decide"
  whether something should be done or not, depending on the state. This
  will solve the issue that the search results for nodes are not
  reliable when a node is in some state that is not "readying",
  "applying" or "ready".
  
  Very concretely: many recipes are using searches to find attributes
  of another barclamp. The recipes do not expect the search to return
  an empty result (and that's okay, because we know that there must be
  a glance server when we deploy nova, due to barclamp dependencies),
  but that could happen in the past when the node was in "problem" or
  rebooting.
- in a later step, we might want to have a new attribute that will tell
  us which role to apply instead of applying everything.

More generally speaking, it's actually wrong to pretend that a node
stops having a role because it's, say, rebooting. A glance server is
always a glance server.

(cherry picked from commit 7cd73be)
