### PR TITLE
Tune timeouts for ruby_blocks (bsc#992392)

### DIFF
--- a/chef/cookbooks/ceph/recipes/mon.rb
+++ b/chef/cookbooks/ceph/recipes/mon.rb
@@ -62,7 +62,7 @@ unless File.exists?("/var/lib/ceph/mon/ceph-#{node["hostname"]}/done")
       require "timeout"
       monitor_key = ""
       begin
-        Timeout.timeout(300) do
+        Timeout.timeout(600) do
           while monitor_key.empty?
             mon_nodes = get_mon_nodes
             mon_nodes.each do |mon|
@@ -159,7 +159,7 @@ end
       require "timeout"
       auth_key = ""
       begin
-        Timeout.timeout(300) do
+        Timeout.timeout(600) do
           while auth_key.empty?
             get_key = Mixlib::ShellOut.new("ceph auth get-key client.#{auth}")
             auth_key = get_key.run_command.stdout.strip

--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -184,7 +184,7 @@ else
           block do
             require "timeout"
             begin
-              Timeout.timeout(300) do
+              Timeout.timeout(600) do
                 osd_id = ""
                 while osd_id.empty?
                   osd_id = get_osd_id(osd_device["device"])


### PR DESCRIPTION
Increase timeouts for ruby_blocks in `mon.rb` and `osd.rb`, because our CI tests on slow tests environments 

```
[2016-08-09T20:32:44+02:00] FATAL: RuntimeError: ruby_block[get monitor-secret] (ceph::mon line 60) had an error: RuntimeError: Cannot fetch monitor secret from master!
```
