### PR TITLE
Repeat the search for ceph-mon nodes even after initial failure.

### DIFF
--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -38,7 +38,7 @@ include_recipe "ceph::conf"
 package "gdisk"
 
 service_type = node["ceph"]["osd"]["init_style"]
-mons = get_mon_nodes("ceph_bootstrap-osd-secret:*")
+mons = get_mon_nodes
 
 if mons.empty? then
   Chef::Log.fatal("No ceph-mon found")


### PR DESCRIPTION
It seems that the search does not return mon nodes for some initial time.

Ideally, this whole search mechanism should be moved to convergence phase, but that would require larger rewrite of many recipes...
