### PR TITLE
Revert "No need to narrow the search for ceph_bootstrap-osd-secret"

### DIFF
--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -38,7 +38,7 @@ include_recipe "ceph::conf"
 package "gdisk"
 
 service_type = node["ceph"]["osd"]["init_style"]
-mons = get_mon_nodes
+mons = get_mon_nodes("ceph_bootstrap-osd-secret:*")
 
 if mons.empty? then
   Chef::Log.fatal("No ceph-mon found")


### PR DESCRIPTION
This reverts commit 2b3108ed00995061f312ab4a3d93ca8f86c606dc.
It seems that without that additional search criteria the search sometime
returns node with "bootstrap-osd-secret" set to nil.
