### PR TITLE
Fix port number for radosgw with ssl

### DIFF
--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -43,6 +43,7 @@ if is_rgw
   else
     rgw_port = rgw_use_ssl ? node["ceph"]["radosgw"]["rgw_port_ssl"] : node["ceph"]["radosgw"]["rgw_port"]
   end
+  rgw_port = rgw_port.to_s + "s" if rgw_use_ssl
   rgw_pemfile = node["ceph"]["radosgw"]["ssl"]["pemfile"] if rgw_use_ssl
 end
 


### PR DESCRIPTION
When using ssl, it is necessary to append a literal 's' to the port number of
the frontend.
