### PR TITLE
Add support for deploying Ceph MDS (fate#321033)

### DIFF
--- a/chef/cookbooks/ceph/recipes/mds.rb
+++ b/chef/cookbooks/ceph/recipes/mds.rb
@@ -1,0 +1,73 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node.roles.include?("ceph-mon")
+  include_recipe "ceph::default"
+  include_recipe "ceph::conf"
+else
+  include_recipe "ceph::keyring"
+end
+include_recipe "ceph::server"
+
+directory "/var/lib/ceph/mds/ceph-#{node["hostname"]}" do
+  owner "ceph"
+  group "ceph"
+  mode "0750"
+  recursive true
+  action :create
+end
+
+execute "create mds keyring" do
+  command "ceph auth get-or-create mds.#{node["hostname"]} \
+             osd 'allow rwx' mds 'allow' mon 'allow profile mds' \
+             -o /var/lib/ceph/mds/ceph-#{node["hostname"]}/keyring ; \
+           chown ceph.ceph /var/lib/ceph/mds/ceph-#{node["hostname"]}/keyring"
+  not_if { File.exist?("/var/lib/ceph/mds/ceph-#{node["hostname"]}/keyring") }
+end
+
+service "ceph_mds" do
+  service_name "ceph-mds@#{node["hostname"]}"
+  supports restart: true, status: true
+  action [:enable, :start]
+  subscribes :restart, resources(template: "/etc/ceph/ceph.conf")
+end
+
+service "ceph-mds.target" do
+  action :enable
+end
+service "ceph.target" do
+  action :enable
+end
+
+execute "create data pool" do
+  # Using `rados mkpool` in order to have it pick up the default pg_num from
+  # ceph.conf (compare `ceph osd pool create`, which requires the pg_num to
+  # be specified on the command line)
+  command "rados mkpool #{node[:ceph][:cephfs][:data_pool]}"
+  not_if "rados lspools|grep -q '^#{node[:ceph][:cephfs][:data_pool]}$'"
+end
+
+execute "create metadata pool" do
+  command "rados mkpool #{node[:ceph][:cephfs][:metadata_pool]}"
+  not_if "rados lspools|grep -q '^#{node[:ceph][:cephfs][:metadata_pool]}$'"
+end
+
+execute "create cephfs filesystem" do
+  # NOTE: not_if condition will be fragile if `ceph fs ls` output ever changes
+  command "ceph fs new #{node[:ceph][:cephfs][:fs_name]} \
+             #{node[:ceph][:cephfs][:metadata_pool]} #{node[:ceph][:cephfs][:data_pool]}"
+  not_if "ceph fs ls|grep -q 'name: #{node[:ceph][:cephfs][:fs_name]},"
+end

--- a/chef/cookbooks/ceph/recipes/role_ceph_mds.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_mds.rb
@@ -1,0 +1,19 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "ceph", "ceph-mds")
+  include_recipe "ceph::mds"
+end

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -71,16 +71,6 @@
   <% end -%>
 <% end -%>
 
-; mds
-;  You need at least one.  Define two to get a standby.
-[mds]
-    ; where the mds keeps it's secret encryption keys
-    keyring = /etc/ceph/$name.keyring
-
-    ; mds logging to debug issues.
-    ;debug ms = 1
-    ;debug mds = 20
-
 ; osd
 ;  You need at least one.  Two if you want data to be replicated.
 ;  Define as many as you like.

--- a/chef/data_bags/crowbar/migrate/ceph/101_add_cephfs.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/101_add_cephfs.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  a["cephfs"] = ta["cephfs"]
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("cephfs")
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceph.json
+++ b/chef/data_bags/crowbar/template-ceph.json
@@ -40,6 +40,11 @@
           "certfile": "/etc/apache2/ssl.crt/calamari-server.crt",
           "keyfile": "/etc/apache2/ssl.key/calamari-server.key"
         }
+      },
+      "cephfs": {
+        "fs_name": "cephfs",
+        "data_pool": "cephfs_data",
+        "metadata_pool": "cephfs_metadata"
       }
     }
   },
@@ -47,25 +52,28 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "ceph-calamari": [ "readying", "ready", "applying" ],
         "ceph-mon": [ "readying", "ready", "applying" ],
         "ceph-osd": [ "readying", "ready", "applying" ],
-        "ceph-radosgw": [ "readying", "ready", "applying" ]
+        "ceph-radosgw": [ "readying", "ready", "applying" ],
+        "ceph-mds": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
         [ "ceph-calamari" ],
         [ "ceph-mon" ],
         [ "ceph-osd" ],
-        [ "ceph-radosgw" ]
+        [ "ceph-radosgw" ],
+        [ "ceph-mds" ]
       ],
       "element_run_list_order": {
         "ceph-calamari": 79,
         "ceph-mon": 80,
         "ceph-osd": 81,
-        "ceph-radosgw": 82
+        "ceph-radosgw": 82,
+        "ceph-mds": 83
       },
       "config": {
         "environment": "ceph-base-config",

--- a/chef/data_bags/crowbar/template-ceph.schema
+++ b/chef/data_bags/crowbar/template-ceph.schema
@@ -77,6 +77,15 @@
                   }
                 }
               }
+            },
+            "cephfs": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "fs_name": { "type": "str", "required": true },
+                "data_pool": { "type": "str", "required": true },
+                "metadata_pool": { "type": "str", "required": true }
+              }
             }
           }
         }

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -78,6 +78,15 @@ class CephService < PacemakerServiceObject
             "opensuse" => "/.*/"
           },
           "cluster" => true
+        },
+        "ceph-mds" => {
+          "unique" => false,
+          "count" => 3,
+          "platform" => {
+            "suse" => "/^12.*/",
+            "opensuse" => "/.*/"
+          },
+          "conflicts_with" => ["ceph-osd"]
         }
       }
     end


### PR DESCRIPTION
This is a rough minimum, still needs some tweaks (see the TODOs),
and definitely needs more testing, but it _does_ work ;)

Open questions:
- Do we require the MDS to run on a separate node, or can it be
  colocated with a MON or OSD?
- Are we allowed to deploy multiple MDSes?
  - If so, how many?  There's no limit enforced presently.
- Should we expose the cephfs filesystem name, and data and metadata
  pool names to the user for editing in the GUI?
- Should we suggest a node for the MDS role by default (as is done
  for rgw?)

Possible problems:
- If you upgrade a system with a ceph proposal that already exists,
  the ceph-mds role isn't made available in the UI, but if you delete
  the proposal then re-create it, the ceph-mds role appears.
  Presumably we'd just want the role to appear as available so it
  could be added to an existing proposal (I shall assume I have missed
  some relevant piece of magic somewhere, or screwed up testing and
  need to re-test).

Signed-off-by: Tim Serong tserong@suse.com
