### PR TITLE
enable API endpoint to check the storage repos

### DIFF
--- a/crowbar_framework/app/controllers/api/storages_controller.rb
+++ b/crowbar_framework/app/controllers/api/storages_controller.rb
@@ -15,6 +15,8 @@
 #
 
 class Api::StoragesController < ApiController
+  before_action :set_ceph
+
   api :GET, "/api/storages", "List all Ceph storages"
   api_version "2.0"
   def index
@@ -31,6 +33,12 @@ class Api::StoragesController < ApiController
   api :GET, "/api/storages/repocheck", "Sanity check ceph repositories"
   api_version "2.0"
   def repocheck
-    render json: {}, status: :not_implemented
+    render json: @ceph.repocheck
+  end
+
+  protected
+
+  def set_ceph
+    @ceph = Api::Storage.new
   end
 end

--- a/crowbar_framework/app/models/api/storage.rb
+++ b/crowbar_framework/app/models/api/storage.rb
@@ -15,6 +15,9 @@
 #
 
 module Api
-  class Storages
+  class Storage < Tableless
+    def repocheck
+      Api::Node.new.repocheck(addon: "ceph")
+    end
   end
 end


### PR DESCRIPTION
@vuntz @jsuchome as I understood we also need to check for the system repos here (sp2), right?

If the check is correct I would like to move it to `crowbar-core` somewhere, where it can be reused, when we add the checks to `crowbar-ha`.

and the other thing is, if the repos are not enabled/active I guess we just activate them, right? at least that's how we did it in the last upgrade from 5 to 6

depends on: ~~https://github.com/crowbar/crowbar-core/pull/633~~ https://github.com/crowbar/crowbar-core/pull/644
