### PR TITLE
Add ceph_client network (fate#319122)

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -93,7 +93,11 @@ def get_mon_addresses()
 
     mons += get_mon_nodes()
     if is_crowbar?
-      mon_ips = mons.map { |node| Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address }
+      mon_ips = mons.map do |node|
+        Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+          node, node["ceph"]["client_network"]
+        ).address
+      end
     else
       if node["ceph"]["config"] && node["ceph"]["config"]["public-network"]
         mon_ips = mons.map { |nodeish| find_node_ip_in_network(node["ceph"]["config"]["public-network"], nodeish) }
@@ -158,8 +162,12 @@ def get_osd_nodes()
     cluster_addr = ""
     public_addr = ""
 
-    public_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-    cluster_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "storage").address
+    public_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+      node, node["ceph"]["client_network"]
+    ).address
+    cluster_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+      node, "storage"
+    ).address
 
     osd = {}
     osd[:hostname] = node.name.split(".")[0]

--- a/chef/cookbooks/ceph/recipes/mds.rb
+++ b/chef/cookbooks/ceph/recipes/mds.rb
@@ -1,0 +1,73 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if node.roles.include?("ceph-mon")
+  include_recipe "ceph::default"
+  include_recipe "ceph::conf"
+else
+  include_recipe "ceph::keyring"
+end
+include_recipe "ceph::server"
+
+directory "/var/lib/ceph/mds/ceph-#{node["hostname"]}" do
+  owner "ceph"
+  group "ceph"
+  mode "0750"
+  recursive true
+  action :create
+end
+
+execute "create mds keyring" do
+  command "ceph auth get-or-create mds.#{node["hostname"]} \
+             osd 'allow rwx' mds 'allow' mon 'allow profile mds' \
+             -o /var/lib/ceph/mds/ceph-#{node["hostname"]}/keyring ; \
+           chown ceph.ceph /var/lib/ceph/mds/ceph-#{node["hostname"]}/keyring"
+  not_if { File.exist?("/var/lib/ceph/mds/ceph-#{node["hostname"]}/keyring") }
+end
+
+service "ceph_mds" do
+  service_name "ceph-mds@#{node["hostname"]}"
+  supports restart: true, status: true
+  action [:enable, :start]
+  subscribes :restart, resources(template: "/etc/ceph/ceph.conf")
+end
+
+service "ceph-mds.target" do
+  action :enable
+end
+service "ceph.target" do
+  action :enable
+end
+
+execute "create data pool" do
+  # Using `rados mkpool` in order to have it pick up the default pg_num from
+  # ceph.conf (compare `ceph osd pool create`, which requires the pg_num to
+  # be specified on the command line)
+  command "rados mkpool #{node[:ceph][:cephfs][:data_pool]}"
+  not_if "rados lspools|grep -q '^#{node[:ceph][:cephfs][:data_pool]}$'"
+end
+
+execute "create metadata pool" do
+  command "rados mkpool #{node[:ceph][:cephfs][:metadata_pool]}"
+  not_if "rados lspools|grep -q '^#{node[:ceph][:cephfs][:metadata_pool]}$'"
+end
+
+execute "create cephfs filesystem" do
+  # NOTE: not_if condition will be fragile if `ceph fs ls` output ever changes
+  command "ceph fs new #{node[:ceph][:cephfs][:fs_name]} \
+             #{node[:ceph][:cephfs][:metadata_pool]} #{node[:ceph][:cephfs][:data_pool]}"
+  not_if "ceph fs ls|grep -q 'name: #{node[:ceph][:cephfs][:fs_name]},"
+end

--- a/chef/cookbooks/ceph/recipes/role_ceph_mds.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_mds.rb
@@ -1,0 +1,19 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if CrowbarRoleRecipe.node_state_valid_for_role?(node, "ceph", "ceph-mds")
+  include_recipe "ceph::mds"
+end

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -71,16 +71,6 @@
   <% end -%>
 <% end -%>
 
-; mds
-;  You need at least one.  Define two to get a standby.
-[mds]
-    ; where the mds keeps it's secret encryption keys
-    keyring = /etc/ceph/$name.keyring
-
-    ; mds logging to debug issues.
-    ;debug ms = 1
-    ;debug mds = 20
-
 ; osd
 ;  You need at least one.  Two if you want data to be replicated.
 ;  Define as many as you like.

--- a/chef/data_bags/crowbar/migrate/ceph/101_add_cephfs.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/101_add_cephfs.rb
@@ -1,0 +1,15 @@
+def upgrade(ta, td, a, d)
+  a["cephfs"] = ta["cephfs"]
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("cephfs")
+  d["element_states"] = td["element_states"]
+  d["element_order"] = td["element_order"]
+  d["element_run_list_order"] = td["element_run_list_order"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/ceph/102_add_client_network.rb
+++ b/chef/data_bags/crowbar/migrate/ceph/102_add_client_network.rb
@@ -1,0 +1,19 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "client_network"
+    # Force client_network to "admin" here during upgrades,
+    # so ceph client network will match existing deploys.
+    # New deployments will default to the value actually
+    # in the template ("public")
+    a["client_network"] = "admin"
+  end
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key? "client_network"
+    a.delete("client_network")
+  end
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ceph.json
+++ b/chef/data_bags/crowbar/template-ceph.json
@@ -16,6 +16,7 @@
       "keystone_instance": "none",
       "service_user": "ceph",
       "service_password": "",
+      "client_network": "public",
       "osd": {
         "min_size_gb": 20,
         "journal_size"  : 5120,
@@ -52,7 +53,7 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "ceph-calamari": [ "readying", "ready", "applying" ],
         "ceph-mon": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ceph.json
+++ b/chef/data_bags/crowbar/template-ceph.json
@@ -40,6 +40,11 @@
           "certfile": "/etc/apache2/ssl.crt/calamari-server.crt",
           "keyfile": "/etc/apache2/ssl.key/calamari-server.key"
         }
+      },
+      "cephfs": {
+        "fs_name": "cephfs",
+        "data_pool": "cephfs_data",
+        "metadata_pool": "cephfs_metadata"
       }
     }
   },
@@ -47,25 +52,28 @@
     "ceph": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "ceph-calamari": [ "readying", "ready", "applying" ],
         "ceph-mon": [ "readying", "ready", "applying" ],
         "ceph-osd": [ "readying", "ready", "applying" ],
-        "ceph-radosgw": [ "readying", "ready", "applying" ]
+        "ceph-radosgw": [ "readying", "ready", "applying" ],
+        "ceph-mds": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
         [ "ceph-calamari" ],
         [ "ceph-mon" ],
         [ "ceph-osd" ],
-        [ "ceph-radosgw" ]
+        [ "ceph-radosgw" ],
+        [ "ceph-mds" ]
       ],
       "element_run_list_order": {
         "ceph-calamari": 79,
         "ceph-mon": 80,
         "ceph-osd": 81,
-        "ceph-radosgw": 82
+        "ceph-radosgw": 82,
+        "ceph-mds": 83
       },
       "config": {
         "environment": "ceph-base-config",

--- a/chef/data_bags/crowbar/template-ceph.schema
+++ b/chef/data_bags/crowbar/template-ceph.schema
@@ -77,6 +77,15 @@
                   }
                 }
               }
+            },
+            "cephfs": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "fs_name": { "type": "str", "required": true },
+                "data_pool": { "type": "str", "required": true },
+                "metadata_pool": { "type": "str", "required": true }
+              }
             }
           }
         }

--- a/chef/data_bags/crowbar/template-ceph.schema
+++ b/chef/data_bags/crowbar/template-ceph.schema
@@ -29,6 +29,7 @@
             "keystone_instance": { "type": "str", "required": true },
             "service_user": { "type": "str", "required": true },
             "service_password": { "type": "str", "required": true },
+            "client_network": { "type": "str", "required": true },
             "osd": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -78,6 +78,15 @@ class CephService < PacemakerServiceObject
             "opensuse" => "/.*/"
           },
           "cluster" => true
+        },
+        "ceph-mds" => {
+          "unique" => false,
+          "count" => 3,
+          "platform" => {
+            "suse" => "/^12.*/",
+            "opensuse" => "/.*/"
+          },
+          "conflicts_with" => ["ceph-osd"]
         }
       }
     end

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -158,9 +158,11 @@ class CephService < PacemakerServiceObject
     @logger.debug("ceph apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     monitors = role.override_attributes["ceph"]["elements"]["ceph-mon"] || []
     osd_nodes = role.override_attributes["ceph"]["elements"]["ceph-osd"] || []
+    ceph_client = role.default_attributes["ceph"]["client_network"]
 
     @logger.debug("monitors: #{monitors.inspect}")
     @logger.debug("osd_nodes: #{osd_nodes.inspect}")
+    @logger.debug("client_network: #{ceph_client}")
 
     radosgw_elements, radosgw_nodes, ha_enabled = role_expand_elements(role, "ceph-radosgw")
 
@@ -175,10 +177,16 @@ class CephService < PacemakerServiceObject
 
     osd_nodes.each do |n|
       net_svc.allocate_ip "default", "storage", "host", n
+      unless ceph_client == "admin" || ceph_client == "storage"
+        net_svc.allocate_ip "default", ceph_client, "host", n
+      end
     end
 
     radosgw_nodes.each do |n|
       net_svc.allocate_ip "default", "public", "host", n
+      unless ceph_client == "admin" || ceph_client == "public"
+        net_svc.allocate_ip "default", ceph_client, "host", n
+      end
     end
 
     # No specific need to call sync dns here, as the cookbook doesn't require
@@ -188,11 +196,11 @@ class CephService < PacemakerServiceObject
     # Save net info in attributes if we're applying
     unless all_nodes.empty?
       node = NodeObject.find_node_by_name osd_nodes[0]
-      admin_net = node.get_network_by_type("admin")
+      client_net = node.get_network_by_type(ceph_client)
       cluster_net = node.get_network_by_type("storage")
 
       role.default_attributes["ceph"]["config"]["public-network"] =
-        "#{admin_net['subnet']}/#{mask_to_bits(admin_net['netmask'])}"
+        "#{client_net["subnet"]}/#{mask_to_bits(client_net["netmask"])}"
       role.default_attributes["ceph"]["config"]["cluster-network"] =
         "#{cluster_net['subnet']}/#{mask_to_bits(cluster_net['netmask'])}"
 


### PR DESCRIPTION
This adds a separate ceph client network, instead of having ceph
client traffic go over the admin network.

I'm not clear on exactly what this will do if applied to an
existing cluster that's already using the admin network for client
traffic.  I mean, it'll rewrite ceph.conf to use the new network,
but I haven't tried it agaist an existing cluster to see if it
actually works.

Signed-off-by: Tim Serong tserong@suse.com
