### PR TITLE
Allow custom config section in ceph.conf

### DIFF
--- a/chef/cookbooks/ceph/attributes/conf.rb
+++ b/chef/cookbooks/ceph/attributes/conf.rb
@@ -1,5 +1,8 @@
 default["ceph"]["config"] = {}
-default["ceph"]["config-sections"] = {}
 default["ceph"]["config"]["fsid"] = "11dd315a-2cab-4130-a760-b285324ef622"
 default["ceph"]["config"]["osds_in_total"] = 0
 default["ceph"]["config"]["replicas_number"] = 0
+
+# possibility to add extra config sections to ceph.conf
+# where "key" is the section name and value the section content
+default["ceph"]["config_sections"] = {}

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -141,3 +141,10 @@
   <% end -%>
 <% end -%>
 <% end -%>
+
+<% if (! node['ceph']['config_sections'].nil?) -%>
+  <% node['ceph']['config_sections'].each do |section_name, section_content| -%>
+[<%= section_name -%>]
+<%= section_content %>
+  <% end -%>
+<% end -%>


### PR DESCRIPTION
Use the default["ceph"]["config_sections"] attribute to allow
adding extra sections in ceph.conf .
This is needed eg. for Manila (which uses the ceph.conf)  where the
client used by the manila-share service needs some extra parameters like
"client mount uid" and "client mount gid = 0".

Also remove the unused default["ceph"]["config-sections"] attribute.