### PR TITLE
Allow MONs and OSDs to be deployed on separate hosts (SOC7/SES4 regression)

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -158,23 +158,8 @@ def get_osd_nodes()
   end
 
   search(:node, search_string).each do |node|
-    port_counter = 6799
-    cluster_addr = ""
-    public_addr = ""
-
-    public_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
-      node, node["ceph"]["client_network"]
-    ).address
-    cluster_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
-      node, "storage"
-    ).address
-
     osd = {}
     osd[:hostname] = node.name.split(".")[0]
-    osd[:cluster_addr] = cluster_addr
-    osd[:cluster_port] = (port_counter += 1)
-    osd[:public_addr] = public_addr
-    osd[:public_port] = (port_counter += 1)
     osds << osd
   end
 

--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -161,6 +161,7 @@ class CephService < PacemakerServiceObject
     @logger.debug("ceph apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     monitors = role.override_attributes["ceph"]["elements"]["ceph-mon"] || []
     osd_nodes = role.override_attributes["ceph"]["elements"]["ceph-osd"] || []
+    mds_nodes = role.override_attributes["ceph"]["elements"]["ceph-mds"] || []
     ceph_client = role.default_attributes["ceph"]["client_network"]
 
     @logger.debug("monitors: #{monitors.inspect}")
@@ -177,6 +178,18 @@ class CephService < PacemakerServiceObject
 
     # Make sure to use the storage network
     net_svc = NetworkService.new @logger
+
+    monitors.each do |n|
+      unless ceph_client == "admin"
+        net_svc.allocate_ip "default", ceph_client, "host", n
+      end
+    end
+
+    mds_nodes.each do |n|
+      unless ceph_client == "admin"
+        net_svc.allocate_ip "default", ceph_client, "host", n
+      end
+    end
 
     osd_nodes.each do |n|
       net_svc.allocate_ip "default", "storage", "host", n


### PR DESCRIPTION
This is kind of important, because without it all MONs also need to be OSDs, and vice versa (see https://bugzilla.suse.com/show_bug.cgi?id=1015069 and/or the commit messages for further details)