### PR TITLE
Calamari also conflicts with database (bsc#1001946)

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -52,7 +52,8 @@ class CephService < PacemakerServiceObject
             "suse" => "/^12.*/",
             "opensuse" => "/.*/"
           },
-          "conflicts_with" => ["ceph-mon", "ceph-osd", "ceph-radosgw", "horizon-server"]
+          "conflicts_with" => ["ceph-mon", "ceph-osd", "ceph-radosgw",
+                               "database-server", "horizon-server"]
         },
         "ceph-mon" => {
           "unique" => false,


### PR DESCRIPTION
Calamari messes by itself with the postgresql database, so
sharing that with the rest of the openstack database is
dangerous.