### PR TITLE
ceph: Specify the public address for the ceph-mon daemon

### DIFF
--- a/chef/cookbooks/ceph/recipes/conf.rb
+++ b/chef/cookbooks/ceph/recipes/conf.rb
@@ -3,6 +3,10 @@ raise "fsid must be set in config" if node["ceph"]["config"]["fsid"].nil?
 mon_nodes = get_mon_nodes
 osd_nodes = get_osd_nodes
 mon_addr = get_mon_addresses
+public_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(
+  node,
+  node["ceph"]["client_network"]
+).address
 
 mon_init = []
 mon_nodes.each do |monitor|
@@ -114,6 +118,7 @@ template "/etc/ceph/ceph.conf" do
     pool_size: rep_num,
     pool_pg_num: pg_num,
     osd_nodes_count: osd_nodes.length,
+    public_addr: public_addr,
     public_network: node["ceph"]["config"]["public-network"],
     cluster_network: node["ceph"]["config"]["cluster-network"],
     is_rgw: is_rgw,
@@ -158,6 +163,7 @@ if is_rgw && node["platform_family"] == "suse"
       pool_size: rep_num,
       pool_pg_num: pg_num,
       osd_nodes_count: osd_nodes.length,
+      public_addr: public_addr,
       public_network: node["ceph"]["config"]["public-network"],
       cluster_network: node["ceph"]["config"]["cluster-network"],
       is_rgw: is_rgw,

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -20,8 +20,8 @@
 
         ; specify the initial monitors of the cluster in to establish a quorum
         mon initial members = <%= @mon_initial.join(', ') %>
-        mon host = <%= @mon_addresses.join(', ') %>    
-        
+        mon host = <%= @mon_addresses.join(', ') %>
+
         ; configure a public and cluster network
         public network = <%= @public_network %>
         cluster network = <%= @cluster_network %>
@@ -65,6 +65,10 @@
     ;debug mon = 20
     ;debug paxos = 20
     ;debug auth = 20
+
+    ; The IP address for the public (front-side) network. Set for each daemon.
+    public addr = <%= @public_addr %>
+
 <% if (! node['ceph']['config']['mon'].nil?) -%>
   <% node['ceph']['config']['mon'].each do |k, v| -%>
   <%= k %> = <%= v %>


### PR DESCRIPTION
In case there is several different IP addresses in the nodes
under the same subnet, the mon daemon will bind to the first one
and we may not want that. So instead, set specifically the
address that the daemon needs to bind to.