### PR TITLE
ceph: Fix integration with external ceph clusters (bsc#1025674)

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -13,7 +13,12 @@ def get_ceph_client_name(cnode)
     net_name = node["ceph"]["client_network"]
   else
     mons = get_mon_nodes
-    net_name = mons[0]["ceph"]["client_network"]
+    net_name = if mons.empty?
+      # case of external clusters
+      "admin"
+    else
+      mons[0]["ceph"]["client_network"]
+    end
   end
   node_name = cnode["hostname"]
   if net_name == "admin"


### PR DESCRIPTION
With an external ceph cluster, a chef search for mons will result in no
result, and that means we're not able to get the network that is used
for ceph. And we're crashing.

But with external ceph clusters, this information is only used to decide
which hostname to use (since we pick a hostname based on the network),
and that's actually irrelevant: the value for the hostname actually only
really matters for nodes that are part of the ceph clusters, not for
client nodes -- and the code is only used for client nodes when we're
using an external ceph cluster.

https://bugzilla.suse.com/show_bug.cgi?id=1025674