### PR TITLE
Update RGW HA deployment to use systemd services (bsc#956582)

### DIFF
--- a/chef/cookbooks/ceph/attributes/radosgw.rb
+++ b/chef/cookbooks/ceph/attributes/radosgw.rb
@@ -60,7 +60,6 @@ default["ceph"]["radosgw"]["ssl"]["generate_certs"] = false
 default["ceph"]["radosgw"]["ssl"]["insecure"] = false
 
 default["ceph"]["ha"]["radosgw"]["enabled"] = false
-default["ceph"]["ha"]["radosgw"]["agent"] = "systemd:#{default['ceph']['radosgw']['service_name']}"
 default["ceph"]["ha"]["radosgw"]["op"]["monitor"]["interval"] = "10s"
 default["ceph"]["ha"]["ports"]["radosgw_plain"] = 5590
 default["ceph"]["ha"]["ports"]["radosgw_ssl"] = 5591

--- a/chef/cookbooks/ceph/recipes/radosgw.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw.rb
@@ -72,24 +72,24 @@ if node["platform_family"] == "suse"
   end
 end
 
-service "radosgw" do
-  service_name service_name
-  supports restart: true
-  action [:enable, :start]
-  subscribes :restart, "template[/etc/ceph/#{rgw_conf}]"
-end
-
-# In the systemd case, need extra targets enabled
-service "ceph-radosgw.target" do
-  action :enable
-  only_if { File.exist?("/usr/lib/systemd/system/ceph-radosgw.target") }
-end
-service "ceph.target" do
-  action :enable
-  only_if { File.exist?("/usr/lib/systemd/system/ceph.target") }
-end
-
 if node[:ceph][:ha][:radosgw][:enabled]
   log "HA support for ceph-radosgw is enabled"
   include_recipe "ceph::radosgw_ha"
+else
+  service "radosgw" do
+    service_name service_name
+    supports restart: true
+    action [:enable, :start]
+    subscribes :restart, "template[/etc/ceph/#{rgw_conf}]"
+  end
+
+  # In the systemd case, need extra targets enabled
+  service "ceph-radosgw.target" do
+    action :enable
+    only_if { File.exist?("/usr/lib/systemd/system/ceph-radosgw.target") }
+  end
+  service "ceph.target" do
+    action :enable
+    only_if { File.exist?("/usr/lib/systemd/system/ceph.target") }
+  end
 end

--- a/chef/cookbooks/ceph/recipes/radosgw_ha.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_ha.rb
@@ -33,29 +33,37 @@ crowbar_pacemaker_sync_mark "wait-ceph-radosgw_ha_resources"
 
 transaction_objects = []
 
-service_name = "ceph-radosgw"
+# stolen from radosgw.rb, sort of; we're using just the instance name
+# for the pacemaker primitive, because rgw.hostname is enough to make
+# it unique, and anyway we can't prefix it with "ceph-radosgw@" because
+# '@' is invalid in pacemaker primitive IDs...
+rgw_hostname = get_ceph_client_name(node)
+service_name = "rgw.#{rgw_hostname}"
+
 pacemaker_primitive service_name do
-  agent node[:ceph][:ha][:radosgw][:agent]
+  # ...but we still need the full "ceph-radosgw@..." form here for systemd.
+  agent "systemd:ceph-radosgw@#{service_name}"
   op node[:ceph][:ha][:radosgw][:op]
   action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 transaction_objects << "pacemaker_primitive[#{service_name}]"
 
-clone_name = "cl-#{service_name}"
-pacemaker_clone clone_name do
-  rsc service_name
-  meta ({ "clone-max" => CrowbarPacemakerHelper.num_corosync_nodes(node) })
+location_constraint = "l-#{service_name}"
+pacemaker_location location_constraint do
+  # I tried inf: for this node, but pacemaker would still try to start the
+  # resource on other nodes when this node went down, hence the reversed
+  # -inf for nodes that don't have this hostname (is there a better way
+  # to do this?)
+  definition "location #{location_constraint} #{service_name} " \
+    "rule -inf: #uname ne #{node[:hostname]}"
   action :update
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
-transaction_objects << "pacemaker_clone[#{clone_name}]"
+transaction_objects << "pacemaker_location[#{location_constraint}]"
 
 pacemaker_transaction "ceph-radosgw" do
   cib_objects transaction_objects
   # note that this will also automatically start the resources
   action :commit_new
-  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 crowbar_pacemaker_sync_mark "create-ceph-radosgw_ha_resources"


### PR DESCRIPTION
RGW HA deployments are presently broken; it tries to make a
clone of a ceph-radosgw service, but this doesn't work, because
we've long since been using parameterized systemd services in
the form ceph-radosgw@rgw.$(hostname).  This commit removes
the clone and replaces it with individual primitives for each
host with appropriate location constraints.

Signed-off-by: Tim Serong <tserong@suse.com>