### PR TITLE
Make logger parameter optional

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -37,7 +37,7 @@ def mask_to_bits(mask)
 end
 
 class CephService < PacemakerServiceObject
-  def initialize(thelogger)
+  def initialize(thelogger = nil)
     super(thelogger)
     @bc_name = "ceph"
   end


### PR DESCRIPTION
Since the logger parameter became optional for ServiceObjects[1],
deactivating a proposal has been broken, producing a cryptic error in
the UI:

  wrong number of arguments (0 for 1)

This is because deactivating a proposal causes a lookup of proposal
dependencies which are no longer initialized with an argument[2], but
all of the OpenStack barclamps still require this parameter. This patch
makes the OpenStack barclamps compatible with the new interface, though
more work will need to be done to clean up use of the logger parameter.

[1] https://github.com/crowbar/crowbar-core/pull/1025
[2] https://github.com/crowbar/crowbar-core/pull/1025/files#diff-494b2794304fa30be60cafd3d2c7f161