### PR TITLE
Make sure ceph-mds and ceph-calamari are not deployed to the cluster node.

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -106,6 +106,27 @@ class CephService < PacemakerServiceObject
     answer
   end
 
+  # Helper to find a suitable node for ceph-mds role.
+  # ceph-mds conflicts with ceph-osd, and should not be assigned to the cluster node
+  def select_node_for_mds_role(nodes)
+    # do not modify array given by caller
+    mds_nodes = nodes.dup
+    mds_nodes.delete_if(&:nil?)
+    mds_nodes.reject! do |n|
+      node_is_valid_for_role(n.name, "ceph-mds")
+    end
+
+    mds_node = mds_nodes.find { |n| n.intended_role != "controller" }
+    if mds_node.nil? && !mds_nodes.empty?
+      mds_node = mds_nodes.first
+      @logger.debug("Not enough nodes: putting ceph-mds on controller node (unsupported scenario)")
+    end
+    if mds_node.nil?
+      @logger.warn("Not enough nodes: there seems to be no node for ceph-mds role!")
+    end
+    mds_node
+  end
+
   def create_proposal
     @logger.debug("Ceph create_proposal: entering")
     base = super
@@ -116,14 +137,17 @@ class CephService < PacemakerServiceObject
 
     base["attributes"][@bc_name]["keystone_instance"] = find_dep_proposal("keystone", true)
 
-    nodes = NodeObject.all
+    nodes = NodeObject.all.reject do |n|
+      # Do not deploy any ceph roles to the nodes in HA cluster
+      n.roles.include?("pacemaker-cluster-member")
+    end
 
     osd_nodes = select_nodes_for_role(nodes, "ceph-osd", "storage")
     if osd_nodes.size < 2
       osd_nodes_all = select_nodes_for_role(nodes, "ceph-osd")
       # avoid controllers if possible (ceph should not be used with openstack roles)
       osd_nodes_no_controller = osd_nodes_all.reject do |n|
-        n.intended_role == "controller" || n.roles.include?("pacemaker-cluster-member")
+        n.intended_role == "controller"
       end
       osd_nodes = [osd_nodes, osd_nodes_no_controller, osd_nodes_all].flatten.uniq(&:name)
       osd_nodes = osd_nodes.take(2)
@@ -133,30 +157,21 @@ class CephService < PacemakerServiceObject
 
     if mon_nodes.size < 3
       mon_nodes_more = select_nodes_for_role(nodes, "ceph-mon").reject do |n|
-        n.intended_role == "controller" || n.roles.include?("pacemaker-cluster-member")
+        n.intended_role == "controller"
       end
       mon_nodes = [mon_nodes, mon_nodes_more].flatten.uniq(&:name)
     end
     mon_nodes = mon_nodes.take(mon_nodes.length > 2 ? 3 : 1)
 
-    mds_node = select_nodes_for_role(nodes, "ceph-mds").reject do |n|
-      n.intended_role == "controller" or osd_nodes.include? n or n.roles.include?("pacemaker-cluster-member")
-    end.first
-    if mds_node.nil?
-      mds_node = select_nodes_for_role(nodes, "ceph-mds", "controller").first
-      @logger.debug("Not enought nodes: putting ceph-mds on controller node (unsupported scenario)")
-    end
+    mds_node = select_node_for_mds_role(nodes - osd_nodes)
 
     radosgw_node = select_nodes_for_role(nodes, "ceph-radosgw", "storage").first
 
     # Any spare node after allocating mons and osds is fair game
     # to automatically use as the calamari server
-    calamari_nodes = select_nodes_for_role(nodes, "ceph-calamari")
+    calamari_nodes = select_nodes_for_role(nodes - osd_nodes - mon_nodes, "ceph-calamari")
     calamari_nodes.reject! do |n|
-      osd_nodes.include? n or
-      mon_nodes.include? n or
-      mds_node.name == n.name or
-      n.intended_role == "controller"
+      (!mds_node.nil? && mds_node.name == n.name) || n.intended_role == "controller"
     end
     calamari_node = calamari_nodes.first
 


### PR DESCRIPTION
We cannot use standard `select_nodes_for_role` because it
limits the search for available nodes with 'count' number.