### PR TITLE
Only deploy ceph roles to SP2 nodes.

### DIFF
--- a/crowbar_framework/app/models/ceph_service.rb
+++ b/crowbar_framework/app/models/ceph_service.rb
@@ -49,7 +49,7 @@ class CephService < PacemakerServiceObject
           "unique" => false,
           "count" => 1,
           "platform" => {
-            "suse" => "/^12.*/",
+            "suse" => "<= 12.2",
             "opensuse" => "/.*/"
           },
           "conflicts_with" => ["ceph-mds", "ceph-mon", "ceph-osd", "ceph-radosgw",
@@ -59,7 +59,7 @@ class CephService < PacemakerServiceObject
           "unique" => false,
           "count" => 9,
           "platform" => {
-            "suse" => "/^12.*/",
+            "suse" => "<= 12.2",
             "opensuse" => "/.*/"
           },
           "conflicts_with" => ["ceph-calamari"]
@@ -68,7 +68,7 @@ class CephService < PacemakerServiceObject
           "unique" => false,
           "count" => 150,
           "platform" => {
-            "suse" => "/^12.*/",
+            "suse" => "<= 12.2",
             "opensuse" => "/.*/"
           },
           "conflicts_with" => ["ceph-mds", "ceph-calamari"]
@@ -77,7 +77,7 @@ class CephService < PacemakerServiceObject
           "unique" => false,
           "count" => 1,
           "platform" => {
-            "suse" => "/^12.*/",
+            "suse" => "<= 12.2",
             "opensuse" => "/.*/"
           },
           "cluster" => true,
@@ -87,7 +87,7 @@ class CephService < PacemakerServiceObject
           "unique" => false,
           "count" => 3,
           "platform" => {
-            "suse" => "/^12.*/",
+            "suse" => "<= 12.2",
             "opensuse" => "/.*/"
           },
           "conflicts_with" => ["ceph-osd", "ceph-calamari"]


### PR DESCRIPTION
We do not provide any SES product for SLES12SP3 nodes.

See also https://github.com/crowbar/crowbar-core/pull/1249

Requires https://github.com/crowbar/crowbar-openstack/pull/1012 so that cinder-volume is not deployed to ceph node