### PR TITLE
Add Monasca monitoring

### DIFF
--- a/chef/cookbooks/ceph/recipes/monitor_monasca.rb
+++ b/chef/cookbooks/ceph/recipes/monitor_monasca.rb
@@ -1,11 +1,11 @@
 #
-# Copyright 2016, SUSE LINUX GmbH
+# Copyright 2017 SUSE Linux GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 
-if CrowbarRoleRecipe.node_state_valid_for_role?(node, "ceph", "ceph-osd")
-  include_recipe "ceph::osd"
-  include_recipe "ceph::monitor_monasca"
+return unless node["roles"].include?("monasca-agent")
+
+if node[:monasca][:agent][:monitor_ceph]
+  monasca_agent_plugin_ceph "monasca-agent ceph check" do
+    built_by "crowbar-ceph"
+    use_sudo true
+    cluster_name "ceph" # TODO: use cluster name if it becomes variable
+  end
 end

--- a/chef/cookbooks/ceph/recipes/role_ceph_mon.rb
+++ b/chef/cookbooks/ceph/recipes/role_ceph_mon.rb
@@ -16,4 +16,5 @@
 
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "ceph", "ceph-mon")
   include_recipe "ceph::mon"
+  include_recipe "ceph::monitor_monasca"
 end


### PR DESCRIPTION
This commit enables the Monasca agent's Ceph monitoring plugin on all
nodes that run Ceph services and have the monasca-agent role assigned.

Note: this depends on https://github.com/crowbar/crowbar-openstack/pull/1369 (hence the Do Not Merge, Yet)