### PR TITLE
get_osd_id: silence errors

### DIFF
--- a/chef/cookbooks/ceph/libraries/default.rb
+++ b/chef/cookbooks/ceph/libraries/default.rb
@@ -164,7 +164,7 @@ end
 
 def get_osd_id(device)
   osd_path = %x[mount | grep #{device} | awk '{print $3}'].tr("\n","")
-  osd_id = %x[cat #{osd_path}/whoami].tr("\n","")
+  osd_id = %x[cat #{osd_path}/whoami 2>/dev/null].tr("\n","")
   return osd_id
 end
 


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1073237#c4 & 5

When creating OSDs, it waits for for get_osd_id to return a value
which caused ugly error messages in the logs:
cat: /var/lib/ceph/osd/ceph-7/var/lib/ceph/tmp/mnt.lAtztf/whoami: No such file or directory