### PR TITLE
Do not write fstab entries (bsc#1073237)

### DIFF
--- a/chef/cookbooks/ceph/recipes/osd.rb
+++ b/chef/cookbooks/ceph/recipes/osd.rb
@@ -218,11 +218,6 @@ else
           dirty = true
         end
 
-        execute "Writing Ceph OSD device mappings to fstab" do
-          command "tail -n1 /etc/mtab >> /etc/fstab"
-          action :run
-        end
-
         # No need to specifically enable ceph-osd@N on systemd systems, as this
         # is done automatically by ceph-disk-activate
       end


### PR DESCRIPTION
because it can have races with ceph-disk activate moving mounts
https://bugzilla.suse.com/show_bug.cgi?id=1073237

Also it made the whole OSD allocation less dynamic than it could be.

backport of #105 