### PR TITLE
Hide ceph barclamp from default view (bsc#1076748)

### DIFF
--- a/ceph.yml
+++ b/ceph.yml
@@ -20,7 +20,7 @@ barclamp:
   display: 'Ceph'
   description: 'Distributed object store and file system'
   version: 0
-  user_managed: true
+  user_managed: false
   member:
     - 'openstack'
     - 'suse_enterprise_storage'


### PR DESCRIPTION
We need to see how we can do an external SES integration, but
for now we need to remove the visibility of the internal SES
support as it isn't working anymore for Cloud 8.