### PR TITLE
[5.0] Adapt radosgw to keystone v3

### DIFF
--- a/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
+++ b/chef/cookbooks/ceph/recipes/radosgw_keystone.rb
@@ -4,7 +4,8 @@
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
 register_auth_hash = { user: keystone_settings["admin_user"],
                        password: keystone_settings["admin_password"],
-                       tenant: keystone_settings["admin_tenant"] }
+                       domain: keystone_settings["admin_domain"],
+                       project: keystone_settings["admin_project"] }
 
 crowbar_pacemaker_sync_mark "wait-radosgw_register"
 
@@ -25,7 +26,7 @@ keystone_register "register ceph user" do
   auth register_auth_hash
   user_name keystone_settings["service_user"]
   user_password keystone_settings["service_password"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   action :add_user
 end
 
@@ -36,7 +37,7 @@ keystone_register "give ceph user access" do
   port keystone_settings["admin_port"]
   auth register_auth_hash
   user_name keystone_settings["service_user"]
-  tenant_name keystone_settings["service_tenant"]
+  project_name keystone_settings["service_tenant"]
   role_name "admin"
   action :add_access
 end
@@ -91,7 +92,7 @@ keystone_register "register radosgw endpoint" do
   endpoint_publicURL "#{protocol}://#{public_host}:#{port}/swift/v1"
   endpoint_adminURL "#{protocol}://#{admin_host}:#{port}/swift/v1"
   endpoint_internalURL "#{protocol}://#{admin_host}:#{port}/swift/v1"
-  action :add_endpoint_template
+  action :add_endpoint
 end
 
 crowbar_pacemaker_sync_mark "create-radosgw_register"

--- a/chef/cookbooks/ceph/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ceph/templates/default/ceph.conf.erb
@@ -132,7 +132,8 @@
   <% unless node[:ceph][:keystone_instance].nil? || node[:ceph][:keystone_instance].empty? || @keystone_settings.empty? -%>
   rgw keystone url =  <%= @keystone_settings['admin_auth_url'] %>
   rgw keystone admin user = <%= @keystone_settings['service_user'] %>
-  rgw keystone admin tenant = <%= @keystone_settings['service_tenant'] %>
+  rgw keystone admin domain = <%= @keystone_settings['admin_domain'] %>
+  rgw keystone admin project = <%= @keystone_settings['admin_project'] %>
   rgw keystone admin password = <%= @keystone_settings['service_password'] %>
 <% if @keystone_settings['insecure'] -%>
   rgw keystone verify ssl = false


### PR DESCRIPTION
Needed after crowbar-openstack commit 8774f1a509
Use keystone v3 in config auth urls (SCRD-781)

(cherry picked from commit e62ea4f2e891769af45c3027644672b6a0abbcec)

This is part of https://github.com/crowbar/crowbar-ceph/pull/112 . 

This patch is enough to make old SP2 ceph nodes work under SOC8, without any additional features (e.g. ceph-mgr )